### PR TITLE
fix a typo re `rpp` default

### DIFF
--- a/endpoints/photo/GET_photos.md
+++ b/endpoints/photo/GET_photos.md
@@ -48,7 +48,7 @@ Returns a listing of twenty (up to one hundred) photos for a specified **[photo 
     - 'desc' — Sort in descending order (highest or most-recent first).  This is the default.
 
 - **page** — Return a specific page in the photo stream. Page numbering is 1-based.
-- **rpp** — The number of results to return. Can not be over 100, default 20.
+- **rpp** — The number of results to return. Can not be over 100, default 50.
 - **image_size** — The photo size(s) to be returned. See the documentation on **[photo sizes][]**.
 
 


### PR DESCRIPTION
This says the default is 20, but when querying the API without an `rpp` parameter, I've been receiving 50 records.

Found this while working on the coding challenge :)